### PR TITLE
#62 use req.redirect and req.mount in svelte examples

### DIFF
--- a/examples/svelte/svelte-animated/src/main.js
+++ b/examples/svelte/svelte-animated/src/main.js
@@ -6,7 +6,7 @@ import Base from './pages/Base.svelte';
 import More from './pages/More.svelte';
 
 const outlet = document.getElementById('app')
-const app = crayon.create() 
+const app = crayon.create()
 
 app.use(svelte.router(outlet))
 app.use(transition.loader())
@@ -15,23 +15,22 @@ app.use(animate.defaults({
     duration: 300
 }))
 app.use(animate.routes([
-    { from: '/**',   to: '/more', name: transition.slideLeft  },
-    { from: '/more', to: '/**',   name: transition.slideRight }
+    { from: '/**', to: '/more', name: transition.slideLeft },
+    { from: '/more', to: '/**', name: transition.slideRight }
 ]))
 
-app.path('/', (req, res) => res.redirect('/home'))
+app.path('/', (req, res) => req.redirect('/home'))
 
-app.path('/home', (req, res) => 
-    res.mount(Base, { req, nav: app })
+app.path('/home', (req, res) =>
+    req.mount(Base, { req, nav: app })
 )
 
 app.path('/about', (req, res) =>
-    res.mount(Base, { req, nav: app })
+    req.mount(Base, { req, nav: app })
 )
 
 app.path('/more', (req, res) =>
-    res.mount(More, { req, nav: app })
-) 
+    req.mount(More, { req, nav: app })
+)
 
 app.load()
-

--- a/examples/svelte/svelte-basic/src/main.js
+++ b/examples/svelte/svelte-basic/src/main.js
@@ -4,23 +4,22 @@ import Base from './pages/Base.svelte';
 import More from './pages/More.svelte';
 
 const outlet = document.getElementById('app')
-const app = crayon.create() 
+const app = crayon.create()
 
 app.use(svelte.router(outlet))
 
-app.path('/', (req, res) => res.redirect('/home'))
+app.path('/', (req, res) => req.redirect('/home'))
 
-app.path('/home', (req, res) => 
-    res.mount(Base, { req, nav: app })
+app.path('/home', (req, res) =>
+    req.mount(Base, { req, nav: app })
 )
 
 app.path('/about', (req, res) =>
-    res.mount(Base, { req, nav: app })
+    req.mount(Base, { req, nav: app })
 )
 
 app.path('/more', (req, res) =>
-    res.mount(More, { req, nav: app })
-) 
+    req.mount(More, { req, nav: app })
+)
 
 app.load()
-


### PR DESCRIPTION
## Proposed changes

Svelte examples were broken because in main.js they used res.redirect and res.mount instead of req.redirect and req.mount

## Types of changes

What types of changes does your code introduce to Crayon?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

I tried to run "make test" but I got an error:

```txt
● Validation Error:

  Module ts-jest in the transform option was not found.
         <rootDir> is: /home/acim/Projects/public/crayon/src/kit

  Configuration Documentation:
  https://jestjs.io/docs/configuration.html
```
However, I tested manually in browser and there are no console errors like before.